### PR TITLE
Allow a users image to be null.

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/User.java
+++ b/src/main/java/io/getstream/chat/java/models/User.java
@@ -62,7 +62,7 @@ public class User {
   @JsonProperty("name")
   private String name;
 
-  @NotNull
+  @Nullable
   @JsonProperty("image")
   private String image;
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Currently image is required as a field (i.e. it cannot be null) for a User response. 

However, image is not a required field when creating a user (as per `UserRequestObject.builder()`).

All tests pass locally. For background, please see Zendesk ticket 13175