### PR TITLE
fix: correct signing key is used

### DIFF
--- a/src/main/java/io/getstream/chat/java/services/framework/StreamServiceGenerator.java
+++ b/src/main/java/io/getstream/chat/java/services/framework/StreamServiceGenerator.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Calendar;
 import java.util.Date;
@@ -118,10 +119,8 @@ public class StreamServiceGenerator {
   }
 
   private static @NotNull String jwtToken() {
-    Key signingKey;
-    try {
-      signingKey =
-          new SecretKeySpec(apiSecret.getBytes("UTF-8"), SignatureAlgorithm.HS256.getJcaName());
+    Key signingKey =
+          new SecretKeySpec(apiSecret.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.HS256.getJcaName());
       // We set issued at 5 seconds ago to avoid problems like JWTAuth error: token used before
       // issue
       // at (iat)
@@ -136,9 +135,5 @@ public class StreamServiceGenerator {
           .setIssuedAt(calendar.getTime())
           .signWith(signingKey, SignatureAlgorithm.HS256)
           .compact();
-    } catch (UnsupportedEncodingException e) {
-      log.severe("Should not happen: UTF-8 is not supported");
-      return "";
-    }
   }
 }

--- a/src/test/java/io/getstream/chat/java/UserTest.java
+++ b/src/test/java/io/getstream/chat/java/UserTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static io.getstream.chat.java.models.User.createToken;
+
 public class UserTest extends BasicTest {
 
   @DisplayName("Can list users with no Exception")
@@ -259,5 +261,15 @@ public class UserTest extends BasicTest {
                         testUsersRequestObjects.get(2).getId()),
                     calendar.getTime())
                 .request());
+  }
+
+  @DisplayName("Can generate a user token")
+  @Test
+  void whenGeneratingUserToken_thenNoException() {
+    String userId = RandomStringUtils.randomAlphabetic(10);
+
+    String token = createToken(userId, null, null);
+
+    Assertions.assertEquals(197, token.length());
   }
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Calling `createToken` throws an error: 

```
io.jsonwebtoken.security.WeakKeyException: The signing key's size is 72 bits which is not secure enough for the HS256 algorithm.  The JWT JWA Specification (RFC 7518, Section 3.2) states that keys used with HS256 MUST have a size >= 256 bits (the key size must be greater than or equal to the hash output size).  Consider using the io.jsonwebtoken.security.Keys class's 'secretKeyFor(SignatureAlgorithm.HS256)' method to create a key guaranteed to be secure enough for HS256.  See https://tools.ietf.org/html/rfc7518#section-3.2 for more information.
```

This should fix it by using the correct secret (not key). I've also added a test and set the subject/issuer.