### PR TITLE
[CHAT-2260] Change Permission.Condition type

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/Permission.java
+++ b/src/main/java/io/getstream/chat/java/models/Permission.java
@@ -8,6 +8,7 @@ import io.getstream.chat.java.models.framework.StreamResponseObject;
 import io.getstream.chat.java.services.PermissionService;
 import io.getstream.chat.java.services.framework.StreamServiceGenerator;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -81,7 +82,7 @@ public class Permission {
 
     @Nullable
     @JsonProperty("condition")
-    private String condition;
+    private Map<String, Object> condition;
 
     public static class PermissionCreateRequest extends StreamRequest<StreamResponseObject> {
       @Override
@@ -129,7 +130,7 @@ public class Permission {
 
     @Nullable
     @JsonProperty("condition")
-    private String condition;
+    private Map<String, Object> condition;
 
     public static class PermissionUpdateRequest extends StreamRequest<StreamResponseObject> {
       private PermissionUpdateRequest(@NotNull String id, @NotNull String name) {

--- a/src/test/java/io/getstream/chat/java/PermissionTest.java
+++ b/src/test/java/io/getstream/chat/java/PermissionTest.java
@@ -35,10 +35,21 @@ public class PermissionTest extends BasicTest {
     Map<String, Object> condition = new HashMap<>();
     condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
+        () ->
+            Permission.create()
+                .id(id)
+                .name(name)
+                .action("DeleteChannel")
+                .condition(condition)
+                .request());
     pause();
     Assertions.assertDoesNotThrow(
-        () -> Permission.update(id, name).action("DeleteChannel").condition(condition).owner(true).request());
+        () ->
+            Permission.update(id, name)
+                .action("DeleteChannel")
+                .condition(condition)
+                .owner(true)
+                .request());
   }
 
   @DisplayName("Can retrieve permission")
@@ -49,7 +60,13 @@ public class PermissionTest extends BasicTest {
     Map<String, Object> condition = new HashMap<>();
     condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
+        () ->
+            Permission.create()
+                .id(id)
+                .name(name)
+                .action("DeleteChannel")
+                .condition(condition)
+                .request());
     pause();
     Permission retrievedPermission =
         Assertions.assertDoesNotThrow(() -> Permission.get(id).request()).getPermission();
@@ -64,7 +81,13 @@ public class PermissionTest extends BasicTest {
     Map<String, Object> condition = new HashMap<>();
     condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
+        () ->
+            Permission.create()
+                .id(id)
+                .name(name)
+                .action("DeleteChannel")
+                .condition(condition)
+                .request());
     pause();
     Assertions.assertDoesNotThrow(() -> Permission.delete(id).request());
     pause();
@@ -83,7 +106,13 @@ public class PermissionTest extends BasicTest {
     Map<String, Object> condition = new HashMap<>();
     condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
+        () ->
+            Permission.create()
+                .id(id)
+                .name(name)
+                .action("DeleteChannel")
+                .condition(condition)
+                .request());
     pause();
     List<Permission> permissions =
         Assertions.assertDoesNotThrow(() -> Permission.list().request()).getPermissions();

--- a/src/test/java/io/getstream/chat/java/PermissionTest.java
+++ b/src/test/java/io/getstream/chat/java/PermissionTest.java
@@ -1,7 +1,9 @@
 package io.getstream.chat.java;
 
 import io.getstream.chat.java.models.Permission;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -13,12 +15,15 @@ public class PermissionTest extends BasicTest {
   @Test
   void whenCreatingPermission_thenNoException() {
     String name = RandomStringUtils.randomAlphabetic(10);
+    Map<String, Object> condition = new HashMap<>();
+    condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
         () ->
             Permission.create()
                 .id(RandomStringUtils.randomAlphabetic(10))
                 .name(name)
                 .action("DeleteChannel")
+                .condition(condition)
                 .request());
   }
 
@@ -27,11 +32,13 @@ public class PermissionTest extends BasicTest {
   void whenUpdatingPermission_thenNoException() {
     String name = RandomStringUtils.randomAlphabetic(10);
     String id = RandomStringUtils.randomAlphabetic(10);
+    Map<String, Object> condition = new HashMap<>();
+    condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").request());
+        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
     pause();
     Assertions.assertDoesNotThrow(
-        () -> Permission.update(id, name).action("DeleteChannel").owner(true).request());
+        () -> Permission.update(id, name).action("DeleteChannel").condition(condition).owner(true).request());
   }
 
   @DisplayName("Can retrieve permission")
@@ -39,8 +46,10 @@ public class PermissionTest extends BasicTest {
   void whenRetrievingPermission_thenCorrectName() {
     String name = RandomStringUtils.randomAlphabetic(10);
     String id = RandomStringUtils.randomAlphabetic(10);
+    Map<String, Object> condition = new HashMap<>();
+    condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").request());
+        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
     pause();
     Permission retrievedPermission =
         Assertions.assertDoesNotThrow(() -> Permission.get(id).request()).getPermission();
@@ -52,8 +61,10 @@ public class PermissionTest extends BasicTest {
   void whenDeletingPermission_thenDeleted() {
     String name = RandomStringUtils.randomAlphabetic(10);
     String id = RandomStringUtils.randomAlphabetic(10);
+    Map<String, Object> condition = new HashMap<>();
+    condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").request());
+        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
     pause();
     Assertions.assertDoesNotThrow(() -> Permission.delete(id).request());
     pause();
@@ -69,8 +80,10 @@ public class PermissionTest extends BasicTest {
   void whenListingPermission_thenCanRetrieve() {
     String name = RandomStringUtils.randomAlphabetic(10);
     String id = RandomStringUtils.randomAlphabetic(10);
+    Map<String, Object> condition = new HashMap<>();
+    condition.put("$subject.magic_custom_field", "magic_value");
     Assertions.assertDoesNotThrow(
-        () -> Permission.create().id(id).name(name).action("DeleteChannel").request());
+        () -> Permission.create().id(id).name(name).action("DeleteChannel").condition(condition).request());
     pause();
     List<Permission> permissions =
         Assertions.assertDoesNotThrow(() -> Permission.list().request()).getPermissions();


### PR DESCRIPTION
This PR updates Permission.Condition type to `Map<String, Object>`. API change is not live yet