### PR TITLE
Set callTimeout instead of connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ secring.gpg
 .classpath
 .project
 .settings/
+gradle.properties

--- a/src/main/java/io/getstream/chat/java/services/framework/StreamServiceGenerator.java
+++ b/src/main/java/io/getstream/chat/java/services/framework/StreamServiceGenerator.java
@@ -66,8 +66,8 @@ public class StreamServiceGenerator {
               ? Integer.parseInt(System.getenv("STREAM_CHAT_TIMEOUT"))
               : Integer.getInteger("STREAM_CHAT_TIMEOUT", 10000);
 
-      OkHttpClient.Builder httpClient = new OkHttpClient.Builder()
-          .callTimeout(streamChatTimeout, TimeUnit.MILLISECONDS);
+      OkHttpClient.Builder httpClient =
+          new OkHttpClient.Builder().callTimeout(streamChatTimeout, TimeUnit.MILLISECONDS);
 
       httpClient.interceptors().clear();
       HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor().setLevel(logLevel);


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Set callTimeout instead of connection only

`The call timeout spans the entire call: resolving DNS, connecting, writing the request body, server processing, and reading the response body. If the call requires redirects or retries all must complete within one timeout period.`
