### PR TITLE
feat: add grants to channeltype

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/Channel.java
+++ b/src/main/java/io/getstream/chat/java/models/Channel.java
@@ -2,6 +2,7 @@ package io.getstream.chat.java.models;
 
 import com.fasterxml.jackson.annotation.*;
 import io.getstream.chat.java.exceptions.StreamException;
+import io.getstream.chat.java.models.Channel.AssignRoleRequestData.AssignRoleRequest;
 import io.getstream.chat.java.models.Channel.ChannelExportRequestData.ChannelExportRequest;
 import io.getstream.chat.java.models.Channel.ChannelGetRequestData.ChannelGetRequest;
 import io.getstream.chat.java.models.Channel.ChannelHideRequestData.ChannelHideRequest;
@@ -176,6 +177,18 @@ public class Channel {
     @Nullable
     @JsonProperty("shadow_banned")
     private Boolean shadowBanned;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class RoleAssignment {
+    @Nullable
+    @JsonProperty("channel_role")
+    private String channelRole;
+
+    @Nullable
+    @JsonProperty("user_id")
+    private String userId;
   }
 
   @Builder
@@ -486,6 +499,39 @@ public class Channel {
         return client
             .create(ChannelService.class)
             .update(this.channelType, this.channelId, this.internalBuild());
+      }
+    }
+  }
+
+  @Builder(
+      builderClassName = "AssignRoleRequest",
+      builderMethodName = "",
+      buildMethodName = "internalBuild")
+  public static class AssignRoleRequestData {
+    @Singular
+    @Nullable
+    @JsonProperty("assign_roles")
+    private List<RoleAssignment> assignRoles;
+
+    @Nullable
+    @JsonProperty("message")
+    private MessageRequestObject message;
+
+    public static class AssignRoleRequest extends StreamRequest<ChannelUpdateResponse> {
+      @NotNull private String channelType;
+
+      @NotNull private String channelId;
+
+      private AssignRoleRequest(@NotNull String channelType, @NotNull String channelId) {
+        this.channelId = channelId;
+        this.channelType = channelType;
+      }
+
+      @Override
+      protected Call<ChannelUpdateResponse> generateCall(Client client) {
+        return client
+            .create(ChannelService.class)
+            .assignRoles(this.channelType, this.channelId, this.internalBuild());
       }
     }
   }
@@ -1415,5 +1461,17 @@ public class Channel {
   public static ChannelPartialUpdateRequest partialUpdate(
       @NotNull String type, @NotNull String id) {
     return new ChannelPartialUpdateRequest(type, id);
+  }
+
+  /**
+   * Creates an assign role request
+   *
+   * @param type the channel type
+   * @param id the channel id
+   * @return the created request
+   */
+  @NotNull
+  public static AssignRoleRequest assignRoles(@NotNull String type, @NotNull String id) {
+    return new AssignRoleRequest(type, id);
   }
 }

--- a/src/main/java/io/getstream/chat/java/models/ChannelType.java
+++ b/src/main/java/io/getstream/chat/java/models/ChannelType.java
@@ -120,6 +120,10 @@ public class ChannelType {
   @JsonProperty("permissions")
   private List<Policy> permissions;
 
+  @Nullable
+  @JsonProperty("grants")
+  private Map<String, List<String>> grants;
+
   @Data
   @NoArgsConstructor
   public static class Threshold {
@@ -369,6 +373,10 @@ public class ChannelType {
     protected List<PermissionRequestObject> permissions;
 
     @Nullable
+    @JsonProperty("grants")
+    protected Map<String, List<String>> grants;
+
+    @Nullable
     @JsonProperty("name")
     private String name;
 
@@ -495,6 +503,10 @@ public class ChannelType {
     @Nullable
     @JsonProperty("permissions")
     protected List<PermissionRequestObject> permissions;
+
+    @Nullable
+    @JsonProperty("grants")
+    protected Map<String, List<String>> grants;
 
     public static class ChannelTypeUpdateRequest extends StreamRequest<ChannelTypeUpdateResponse> {
       @NotNull private String name;

--- a/src/main/java/io/getstream/chat/java/services/ChannelService.java
+++ b/src/main/java/io/getstream/chat/java/services/ChannelService.java
@@ -90,4 +90,10 @@ public interface ChannelService {
       @NotNull @Path("type") String channelType,
       @NotNull @Path("id") String channelId,
       @NotNull @Body ChannelPartialUpdateRequestData channelPartialUpdateRequestData);
+
+  @POST("channels/{type}/{id}")
+  Call<ChannelUpdateResponse> assignRoles(
+      @NotNull @Path("type") String channelType,
+      @NotNull @Path("id") String channelId,
+      @NotNull @Body AssignRoleRequestData assignRoleRequestData);
 }

--- a/src/test/java/io/getstream/chat/java/ChannelTest.java
+++ b/src/test/java/io/getstream/chat/java/ChannelTest.java
@@ -312,4 +312,19 @@ public class ChannelTest extends BasicTest {
                     .getChannel());
     Assertions.assertEquals(updatedTeam, updateChannel.getTeam());
   }
+
+  @DisplayName("Can assign roles")
+  @Test
+  void whenAssigningRole_throwsNoError() {
+    Channel channel = Assertions.assertDoesNotThrow(() -> createRandomChannel()).getChannel();
+    var assignment = new RoleAssignment();
+    assignment.setChannelRole("channel_moderator");
+    assignment.setUserId(testUserRequestObject.getId());
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            Channel.assignRoles(channel.getType(), channel.getId())
+                .assignRole(assignment)
+                .request());
+  }
 }

--- a/src/test/java/io/getstream/chat/java/ChannelTypeTest.java
+++ b/src/test/java/io/getstream/chat/java/ChannelTypeTest.java
@@ -8,6 +8,8 @@ import io.getstream.chat.java.models.ChannelType.AutoMod;
 import io.getstream.chat.java.models.ChannelType.ChannelTypeListResponse;
 import io.getstream.chat.java.models.Command;
 import io.getstream.chat.java.models.ResourceAction;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.*;
@@ -131,5 +133,29 @@ public class ChannelTypeTest extends BasicTest {
     pause();
     Assertions.assertDoesNotThrow(
         () -> ChannelType.update(channelName).automod(AutoMod.SIMPLE).request());
+  }
+
+  @DisplayName("Can create channel type with specific grants")
+  @Test
+  void whenManipulatingChannelTypeWithGrants_throwsNoException() {
+    String channelTypeName = RandomStringUtils.randomAlphabetic(10);
+    var expectedGrants = List.of("read-channel", "create-message");
+    var channelGrants = new HashMap<String, List<String>>();
+    channelGrants.put("channel_member", expectedGrants);
+    Assertions.assertDoesNotThrow(
+        () ->
+            ChannelType.create()
+                .withDefaultConfig()
+                .grants(channelGrants)
+                .name(channelTypeName)
+                .request());
+    waitFor(
+        () -> {
+          var channelType =
+              Assertions.assertDoesNotThrow(() -> ChannelType.get(channelTypeName).request());
+          var actualGrants = channelType.getGrants().get("channel_member");
+
+          return new HashSet<>(actualGrants).equals(new HashSet<>(expectedGrants));
+        });
   }
 }


### PR DESCRIPTION
In order to fill up the code snippet examples in the [Permission V2 docs page](https://getstream.io/chat/docs/java/user_permissions/?preview=1&language=java), we need to be able to update grants on channel type level.

So basically this is support for ChannelType grants.