### PR TITLE
ci: fix initiate release job

### DIFF
--- a/.github/workflows/initiate_release.yml
+++ b/.github/workflows/initiate_release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
-          npx --yes standard-version@9.3.2 --release-as "$VERSION" --skip.tag --skip.commit --tag-prefix=v
+          npx --yes standard-version@9.3.2 --release-as "$VERSION" --skip.tag --skip.commit --tag-prefix=
           git config --global user.name 'github-actions' 
           git config --global user.email 'release@getstream.io'
           git checkout -q -b "release-$VERSION"


### PR DESCRIPTION
The tags in this repository does not have v prefix. So it's not v1.5.0 but simply 1.5.0.

This is what this commit is fixing.