### PR TITLE
feat: set pool lifetime to 59seconds

### DIFF
--- a/src/main/java/io/getstream/chat/java/services/framework/DefaultClient.java
+++ b/src/main/java/io/getstream/chat/java/services/framework/DefaultClient.java
@@ -11,6 +11,7 @@ import java.security.Key;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.spec.SecretKeySpec;
+import okhttp3.ConnectionPool;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -76,6 +77,7 @@ public class DefaultClient implements Client {
 
     OkHttpClient.Builder httpClient =
         new OkHttpClient.Builder()
+            .connectionPool(new ConnectionPool(5, 59, TimeUnit.SECONDS))
             .callTimeout(getStreamChatTimeout(properties), TimeUnit.MILLISECONDS);
     httpClient.interceptors().clear();
 


### PR DESCRIPTION
- Set connection pool lifetime from 5 minutes to 59 seconds

https://github.com/square/okhttp/blob/3ad1912f783e108b3d0ad2c4a5b1b89b827e4db9/okhttp/src/jvmMain/kotlin/okhttp3/ConnectionPool.kt#L36