### PR TITLE
docs: update wording in the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For the client-side integrations (web and mobile) have a look at the JavaScript,
 
 ## ⚙️ Installation
 
-> The Stream chat Java SDK requires Java 11+. It supports latest LTS. If you need support an older Java, please contact at [support](https://getstream.io/contact/support/).
+> The Stream chat Java SDK requires Java 8+. It supports latest LTS.
 
 > The Stream chat Java SDK is compatible with Groovy, Scala, Kotlin and Clojure.
 ### Installation for Java


### PR DESCRIPTION
Basically, Lombok require Java9, but the generated code itself can run on Java8. So let's not confuse the customers here.

Also, I removed the last sentence, since I don't think we want to support non-LTS versions.