### PR TITLE
fix: make created_by_id nullable in UserDeactivateRequest

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/User.java
+++ b/src/main/java/io/getstream/chat/java/models/User.java
@@ -775,7 +775,7 @@ public class User {
     @JsonProperty("mark_messages_deleted")
     private Boolean markMessagesDeleted;
 
-    @NotNull
+    @Nullable
     @JsonProperty("created_by_id")
     private String createdById;
 


### PR DESCRIPTION
# Submit a pull request

`created_by_id` is an optional field on deactivate user endpoint - https://getstream.io/chat/docs/python/update_users/?language=python#deactivate-a-user

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
