### PR TITLE
feat: add test for `notifications_muted` query members

### DIFF
--- a/src/test/java/io/getstream/chat/java/ChannelTest.java
+++ b/src/test/java/io/getstream/chat/java/ChannelTest.java
@@ -330,6 +330,21 @@ public class ChannelTest extends BasicTest {
                     .findFirst()
                     .get());
     Assertions.assertTrue(channelMember.getNotificationsMuted());
+
+    ChannelMember chm =
+        Assertions.assertDoesNotThrow(
+            () ->
+                Channel.queryMembers()
+                    .filterCondition("notifications_muted", true)
+                    .id(channel.getId())
+                    .type(channel.getType())
+                    .request()
+                    .getMembers()
+                    .stream()
+                    .filter(cm -> cm.getUserId().equals(testUserRequestObject.getId()))
+                    .findFirst()
+                    .get());
+    Assertions.assertTrue(chm.getNotificationsMuted());
   }
 
   private boolean isChannelMutedForTestUser(String channelType, String channelId) {


### PR DESCRIPTION
This check the `notifications_muted` filter is working correctly for `queryMembers`