### PR TITLE
[PBE-5292] fix: ensure publish tasks run after sign tasks

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -90,6 +90,13 @@ signing {
 	sign publishing.publications
 }
 
+// Ensure that the publish tasks run after the sign tasks, otherwise gradle will complain
+tasks.matching { it.name.startsWith('publish') }.all { publishTask ->
+	tasks.matching { it.name.startsWith('sign') }.all { signTask ->
+		publishTask.mustRunAfter(signTask)
+	}
+}
+
 javadoc {
 	options.addBooleanOption('html5', true)
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Gradle complained about tasks depending on each other.
https://github.com/GetStream/stream-chat-java/actions/runs/10416424942/job/28848632495
