### PR TITLE
[CHA-1050] fix: don't reset webhook events when updating other fields

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/App.java
+++ b/src/main/java/io/getstream/chat/java/models/App.java
@@ -794,6 +794,7 @@ public class App extends StreamResponseObject {
 
     @NotNull
     @JsonProperty("reminders_interval")
+    @JsonInclude(Include.NON_DEFAULT)
     private int remindersInterval;
 
     @Nullable
@@ -883,6 +884,7 @@ public class App extends StreamResponseObject {
 
     @Nullable
     @JsonProperty("webhook_events")
+    @JsonInclude(Include.NON_NULL)
     private List<String> webhookEvents;
 
     @Nullable
@@ -890,10 +892,13 @@ public class App extends StreamResponseObject {
     @JsonInclude(Include.NON_NULL)
     private Boolean multiTenantEnabled;
 
+    static final Date defaultDate = new Date(Long.MIN_VALUE);
+
     @Nullable
     @JsonProperty("revoke_tokens_issued_before")
-    // This field can be sent as null
-    private Date revokeTokensIssuedBefore;
+    @JsonInclude(value = Include.CUSTOM, valueFilter = NonDefaultDateFilter.class)
+    @Builder.Default
+    private Date revokeTokensIssuedBefore = defaultDate;
 
     @Nullable
     @JsonProperty("channel_hide_members_only")
@@ -907,6 +912,7 @@ public class App extends StreamResponseObject {
 
     @Nullable
     @JsonProperty("grants")
+    @JsonInclude(Include.NON_NULL)
     private Map<String, List<String>> grants;
 
     @Nullable
@@ -918,6 +924,17 @@ public class App extends StreamResponseObject {
       @Override
       protected Call<StreamResponseObject> generateCall(Client client) {
         return client.create(AppService.class).update(this.internalBuild());
+      }
+    }
+
+    // Filter that excludes default date and included null (used to reset)
+    static class NonDefaultDateFilter {
+      // Return true if filtering out (excluding), false to include
+      @Override
+      public boolean equals(Object o) {
+        // only ever called with String value
+        Date other = (Date) o;
+        return defaultDate.equals(other);
       }
     }
   }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Updating any field on `App` did reset `webhookEvents`. This PR fixes that.