### PR TITLE
[CHA-1284] feat: add additional fields to channel member request

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/Channel.java
+++ b/src/main/java/io/getstream/chat/java/models/Channel.java
@@ -380,6 +380,18 @@ public class Channel {
     @JsonProperty("shadow_banned")
     private Boolean shadowBanned;
 
+    @Singular @Nullable @JsonIgnore private Map<String, Object> additionalFields;
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalFields() {
+      return this.additionalFields;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String name, Object value) {
+      this.additionalFields.put(name, value);
+    }
+
     @Nullable
     public static ChannelMemberRequestObject buildFrom(@Nullable ChannelMember channelMember) {
       return RequestObjectBuilder.build(ChannelMemberRequestObject.class, channelMember);


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Adds the ability to set additional (custom) fields on channel members.