### PR TITLE
fix: Expose getEventHooks()

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/App.java
+++ b/src/main/java/io/getstream/chat/java/models/App.java
@@ -322,6 +322,10 @@ public class App extends StreamResponseObject {
     @Nullable
     @JsonProperty("user_response_time_enabled")
     private Boolean userResponseTimeEnabled;
+
+    @Nullable
+    @JsonProperty("event_hooks")
+    private List<EventHook> eventHooks;
   }
 
   public enum PermissionVersion {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Exposing `getEventHooks()` so it can be used to get the list of event hooks
