### PR TITLE
fix: Change timeout_ms in event hooks to Number to match the old config

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/App.java
+++ b/src/main/java/io/getstream/chat/java/models/App.java
@@ -500,7 +500,7 @@ public class App extends StreamResponseObject {
 
     @Nullable
     @JsonProperty("timeout_ms")
-    private Integer timeoutMs;
+    private Number timeoutMs;
 
     @Nullable
     @JsonProperty("callback")


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Change timeout_ms in event hooks to Number to match the old async moderation config