### PR TITLE
[MOD2-818] Add delete_reactions support for ban user

### DIFF
--- a/src/main/java/io/getstream/chat/java/models/Moderation.java
+++ b/src/main/java/io/getstream/chat/java/models/Moderation.java
@@ -758,6 +758,10 @@ public class Moderation {
     @JsonProperty("ip_ban")
     private Boolean ipBan;
 
+    @Nullable
+    @JsonProperty("delete_reactions")
+    private Boolean deleteReactions;
+
     public static class BanRequest extends StreamRequest<BanResponse> {
       @Override
       protected Call<BanResponse> generateCall(Client client) {

--- a/src/main/java/io/getstream/chat/java/models/User.java
+++ b/src/main/java/io/getstream/chat/java/models/User.java
@@ -836,6 +836,10 @@ public class User {
     @JsonProperty("channel_cid")
     private String channelCid;
 
+    @Nullable
+    @JsonProperty("delete_reactions")
+    private Boolean deleteReactions;
+
     public static class UserBanRequest extends StreamRequest<StreamResponseObject> {
       @Override
       protected Call<StreamResponseObject> generateCall(Client client) {

--- a/src/test/java/io/getstream/chat/java/UserTest.java
+++ b/src/test/java/io/getstream/chat/java/UserTest.java
@@ -191,6 +191,25 @@ public class UserTest extends BasicTest {
     Assertions.assertTrue(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
   }
 
+  @DisplayName("Can ban user with delete reactions")
+  @Test
+  void whenBanUserWithDeleteReactions_thenIsBanned() {
+    String userId = RandomStringUtils.randomAlphabetic(10);
+    UserUpsertRequest usersUpsertRequest = User.upsert();
+    usersUpsertRequest.user(
+        UserRequestObject.builder().id(userId).name("User to ban with delete reactions").build());
+    Assertions.assertDoesNotThrow(() -> usersUpsertRequest.request());
+    Assertions.assertDoesNotThrow(
+        () ->
+            User.ban()
+                .userId(testUserRequestObject.getId())
+                .targetUserId(userId)
+                .deleteReactions(true)
+                .request());
+    List<Ban> bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
+    Assertions.assertTrue(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
+  }
+
   @DisplayName("Can shadow ban user")
   @Test
   void whenShadowBanUser_thenIsShadowBanned() {


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/MOD2-818

## Summary
Adds `deleteReactions` boolean field to `UserBanRequestData` and `Moderation.BanRequestData` for the ban API. When set to `true`, the backend deletes all reactions by the banned user on other users' messages.

This corresponds to the backend change in https://github.com/GetStream/chat/pull/12495.

## Changes
- `User.UserBanRequestData`: added `delete_reactions` field
- `Moderation.BanRequestData`: added `delete_reactions` field
- `UserTest`: added test for banning a user with `deleteReactions(true)`

## Checklist
- [x] The changed code has been covered with unit tests
- [ ] API endpoints are covered with client tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)