### PR TITLE
chore(tests): clean leftover test state on shared CI app

### DIFF
--- a/src/test/java/io/getstream/chat/java/ChannelTypeTest.java
+++ b/src/test/java/io/getstream/chat/java/ChannelTypeTest.java
@@ -15,6 +15,36 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.*;
 
 public class ChannelTypeTest extends BasicTest {
+
+  private static final java.util.Set<String> SYSTEM_CHANNEL_TYPES =
+      java.util.Set.of("messaging", "livestream", "gaming", "commerce", "team");
+
+  /**
+   * Delete zombie custom channel types left over from prior CI runs that failed mid-test before
+   * their inline {@code ChannelType.delete(...)} could fire. The shared test app caps custom
+   * channel types at 50; without this sweep new branches hit the quota as soon as enough zombie
+   * types accumulate. Only deletes types not in {@link #SYSTEM_CHANNEL_TYPES}.
+   */
+  @BeforeAll
+  static void cleanupLeftoverChannelTypes() {
+    try {
+      var resp = ChannelType.list().request();
+      if (resp == null || resp.getChannelTypes() == null) return;
+      resp.getChannelTypes().keySet().stream()
+          .filter(name -> !SYSTEM_CHANNEL_TYPES.contains(name))
+          .forEach(
+              name -> {
+                try {
+                  ChannelType.delete(name).request();
+                } catch (StreamException ignored) {
+                  // Best-effort: skip types that are in use or already deleted.
+                }
+              });
+    } catch (StreamException ignored) {
+      // Best-effort: if list fails the tests below will surface the real error.
+    }
+  }
+
   @Test
   @DisplayName("Get channel type with populated commands")
   void whenPopulatingCommands_thenFetchChannelTypeWithoutAnyIssues() {

--- a/src/test/java/io/getstream/chat/java/CommandTest.java
+++ b/src/test/java/io/getstream/chat/java/CommandTest.java
@@ -1,13 +1,44 @@
 package io.getstream.chat.java;
 
+import io.getstream.chat.java.exceptions.StreamException;
 import io.getstream.chat.java.models.Command;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class CommandTest extends BasicTest {
+
+  private static final java.util.Set<String> SYSTEM_COMMANDS =
+      java.util.Set.of("giphy", "imgur", "ban", "unban", "mute", "unmute", "flag", "unflag");
+
+  /**
+   * Delete zombie custom commands left over from prior CI runs that failed mid-test before the
+   * inline {@code Command.delete(...)} could fire. The shared test app caps custom commands at 50.
+   * Only deletes commands not in {@link #SYSTEM_COMMANDS}.
+   */
+  @BeforeAll
+  static void cleanupLeftoverCommands() {
+    try {
+      var resp = Command.list().request();
+      if (resp == null || resp.getCommands() == null) return;
+      resp.getCommands().stream()
+          .map(Command::getName)
+          .filter(name -> name != null && !SYSTEM_COMMANDS.contains(name))
+          .forEach(
+              name -> {
+                try {
+                  Command.delete(name).request();
+                } catch (StreamException ignored) {
+                  // Best-effort: skip commands that are in use or already deleted.
+                }
+              });
+    } catch (StreamException ignored) {
+      // Best-effort.
+    }
+  }
 
   @DisplayName("Can create command")
   @Test

--- a/src/test/java/io/getstream/chat/java/TaskStatusTest.java
+++ b/src/test/java/io/getstream/chat/java/TaskStatusTest.java
@@ -20,12 +20,17 @@ public class TaskStatusTest extends BasicTest {
 
           var cids = List.of(ch1.getCId(), ch2.getCId());
           var taskId = Channel.deleteMany(cids).request().getTaskId();
+          // Shared CI test app: asynq queue can be backed up under load — the
+          // default 5s waitFor is routinely too short. 5 minutes leaves real
+          // headroom without masking a stuck task.
           waitFor(
               () -> {
                 var taskStatusResponse =
                     Assertions.assertDoesNotThrow(() -> TaskStatus.get(taskId).request());
                 return "completed".equals(taskStatusResponse.getStatus());
-              });
+              },
+              1000L,
+              300000L);
         });
   }
 }

--- a/src/test/java/io/getstream/chat/java/UserTest.java
+++ b/src/test/java/io/getstream/chat/java/UserTest.java
@@ -23,11 +23,49 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 
 public class UserTest extends BasicTest {
+
+  /**
+   * Clear zombie bans left over from prior CI runs that died before their cleanup could fire.
+   * {@code User.queryBanned().request()} returns a paginated slice; once enough bans accumulate on
+   * the shared test app, the just-created ban under test ends up past the first page and the {@code
+   * assertTrue(bans.stream().anyMatch(...))} assertion fails. Best-effort sweep.
+   */
+  @BeforeAll
+  static void cleanupLeftoverBans() {
+    // queryBanned() returns a paginated slice, so a single pass only clears
+    // the first page. Loop until either the response is empty or we stop
+    // making progress; cap iterations to avoid running forever against a
+    // poisoned app.
+    Set<String> seen = new HashSet<>();
+    for (int round = 0; round < 20; round++) {
+      List<Ban> bans;
+      try {
+        bans = User.queryBanned().request().getBans();
+      } catch (StreamException ignored) {
+        return; // Best-effort.
+      }
+      if (bans == null || bans.isEmpty()) return;
+      int unbannedThisRound = 0;
+      for (var ban : bans) {
+        if (ban.getUser() == null || ban.getUser().getId() == null) continue;
+        String id = ban.getUser().getId();
+        if (!seen.add(id)) continue;
+        try {
+          User.unban(id).request();
+          unbannedThisRound++;
+        } catch (StreamException ignored) {
+          // In-use or already-deleted; skip.
+        }
+      }
+      if (unbannedThisRound == 0) return; // No progress; bail.
+    }
+  }
 
   @DisplayName("Can list users with no Exception")
   @Test


### PR DESCRIPTION
## Summary

Three test classes routinely fail on CI because the shared test app accumulates state across runs whenever a prior PR's job died before its inline teardown could fire. None of these are SDK behavior bugs — they are infra/seeding gaps that surface as red CI on unrelated PRs.

### `ChannelTypeTest` / `CommandTest` — 50-item quota

Both classes tear down their state inline at the end of each test. When a CI run dies mid-test before the `delete(...)` call fires, the leftover entry stays on the shared test app. Once enough zombies accumulate, every new run hits the per-app cap (`CustomChannelTypeLimit = 50`, `CustomCommandLimit = 50` on the backend):

```
StreamException: CreateChannelType failed with error:
    "your application reached the maximum number of custom channel types (50)"
StreamException: CreateCommand failed with error:
    "your application reached the maximum number of custom commands (50)"
```

Blocks 17 tests across the two classes. Add a `@BeforeAll` sweep on each that lists, filters out system defaults, and best-effort deletes the rest.

### `UserTest` — paginated `queryBanned` misses new ban

Several ban-related tests do `User.ban().request()` then `User.queryBanned().request()` and assert the new ban is in the response with `assertTrue(bans.stream().anyMatch(...))`. `queryBanned` returns a paginated slice. Once enough zombie bans accumulate on the shared app the just-created ban ends up past page 1 and the assertion fails with `expected: <true> but was: <false>`.

Fix: `@BeforeAll cleanupLeftoverBans` that **paginates** through `queryBanned()` — up to 20 rounds, stopping early when either the response is empty or we make no progress — and best-effort unbans each entry it sees. Tracks already-seen IDs to avoid wasted calls. Affects 5 tests (`Can ban user`, `Can ban user with delete reactions`, `Can shadow ban user`, `Can list banned user`, `Can unban user`).

### `TaskStatusTest` — default `waitFor` too short for `deleteMany`

`Channel.deleteMany(...).request().getTaskId()` and then poll `TaskStatus.get(taskId)` for completion. The default `waitFor` timeout (5s, defined on `BasicTest`) is routinely too short for the asynq queue under load. Bump that one test to 5 minutes.

All sweeps are best-effort: anything still in active use returns an error from `delete()` / `unban()` and is skipped.

## Test plan

- [x] `./gradlew spotlessCheck compileTestJava` — clean
- [x] CI green on `ChannelTypeTest` + `CommandTest` + `UserTest` + `TaskStatusTest`
