### PR TITLE
[CHA-3267] before_message_send_hook_attempt_timeout_ms

### DIFF
--- a/docs/app_and_channel_settings/app_settings.md
+++ b/docs/app_and_channel_settings/app_settings.md
@@ -70,6 +70,7 @@ These 2 settings are important. Never run with disable_auth_checks or disable_pe
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------- | ------- |
 | custom_action_handler_url    | This webhook reacts to custom /slash commands and actions on those commands/                                    | -       |
 | before_message_send_hook_url | This webhook allows you to modify or moderate message content before sending it to the chat for everyone to see | -       |
+| before_message_send_hook_attempt_timeout_ms | Optional per-attempt HTTP timeout (ms) for the before-message-send hook. `0`/unset = default (1500 ms attempt / 2000 ms overall). Integer **1–5000** sets the attempt timeout; overall envelope is value + 500 ms. | -       |
 
 ### Webhooks, SQS, SNS, and pending messages
 

--- a/docs/webhooks/webhooks_overview/before_message_send_webhook.md
+++ b/docs/webhooks/webhooks_overview/before_message_send_webhook.md
@@ -13,6 +13,16 @@ App
   .request();
 ```
 
+## Per-attempt HTTP timeout
+
+You can optionally set `before_message_send_hook_attempt_timeout_ms` (milliseconds) when updating app settings. **Omitted or `0`** keeps the Stream default (**1500 ms** per HTTP attempt on this hook and **2000 ms** overall for the request envelope). Values from **1** through **5000** set that per-attempt timeout; the overall envelope is the configured value **plus 500 ms**. The API rejects values outside **0–5000**.
+
+```java
+App.update()
+  .beforeMessageSendHookAttemptTimeoutMs(2000)
+  .request();
+```
+
 ## Use-cases
 
 You can use this webhook to enforce any of these rules:
@@ -156,7 +166,9 @@ Not all message fields can be rewritten by your hook handler, fields such as cre
 
 ## Performance considerations
 
-Your webhook endpoint will be part of the send message transaction, so you should avoid performing any remote calls or potentially slow operations while processing the request. Stream Chat will give your endpoint 1 second of time to reply. If your endpoint is not available (ie. returns a response with status codes 4xx or 5xx) or takes too long, Stream Chat will continue with the execution and save the message as usual.
+Your webhook endpoint will be part of the send message transaction, so you should avoid performing any remote calls or potentially slow operations while processing the request.
+
+**Timeouts:** By default, Stream allows **1500 ms** for your HTTP handler to start returning a response (per-attempt timeout), with **2000 ms** for the overall before-message-send request including internal overhead. You can raise the per-attempt budget up to **5000 ms** using `before_message_send_hook_attempt_timeout_ms` (see [Per-attempt HTTP timeout](/chat/docs/java/before_message_send_webhook/#per-attempt-http-timeout)); the overall envelope is always **500 ms** above that per-attempt value. If your endpoint is unavailable (for example HTTP **4xx** or **5xx**) or too slow, Stream **fails open** for this hook: processing continues and the message is stored as usual unless your handler returns a structured rejection.
 
 To make sure that an outage on the hook does not impact your application, Stream will pause your webhook once it is considered unreachable and it will automatically resume once the webhook is found to be healthy again.
 

--- a/src/main/java/io/getstream/chat/java/models/App.java
+++ b/src/main/java/io/getstream/chat/java/models/App.java
@@ -317,6 +317,10 @@ public class App extends StreamResponseObject {
     private String beforeMessageSendHookUrl;
 
     @Nullable
+    @JsonProperty("before_message_send_hook_attempt_timeout_ms")
+    private Integer beforeMessageSendHookAttemptTimeoutMs;
+
+    @Nullable
     @JsonProperty("auto_translation_enabled")
     private Boolean autoTranslationEnabled;
 
@@ -870,6 +874,11 @@ public class App extends StreamResponseObject {
     @JsonProperty("before_message_send_hook_url")
     @JsonInclude(Include.NON_NULL)
     private String beforeMessageSendHookUrl;
+
+    @Nullable
+    @JsonProperty("before_message_send_hook_attempt_timeout_ms")
+    @JsonInclude(Include.NON_NULL)
+    private Integer beforeMessageSendHookAttemptTimeoutMs;
 
     @Nullable
     @JsonProperty("auto_translation_enabled")


### PR DESCRIPTION
## Summary
- Add/support `before_message_send_hook_attempt_timeout_ms` for app settings (before-message-send webhook per-attempt timeout).

## Related
- Backend: https://github.com/GetStream/chat/pull/13541
- Docs: https://github.com/GetStream/docs-content/pull/1304

## Test plan
- [ ] `PATCH /app` includes field in JSON payload where applicable
- [ ] Typed models compile / build succeeds