### PR TITLE
test(user): look up bans by user_id filter to avoid pagination flake

### DIFF
--- a/src/test/java/io/getstream/chat/java/UserTest.java
+++ b/src/test/java/io/getstream/chat/java/UserTest.java
@@ -33,17 +33,17 @@ public class UserTest extends BasicTest {
   /**
    * Clear zombie bans left over from prior CI runs that died before their cleanup could fire.
    * {@code User.queryBanned().request()} returns a paginated slice; once enough bans accumulate on
-   * the shared test app, the just-created ban under test ends up past the first page and the {@code
-   * assertTrue(bans.stream().anyMatch(...))} assertion fails. Best-effort sweep.
+   * the shared test app, every page reads back the same zombies and the {@link #findBanFor} lookup
+   * still has to wade through them. Best-effort sweep: regular, shadow, and channel-scoped bans are
+   * each unbanned with the right qualifiers so the queue actually drains.
    */
   @BeforeAll
   static void cleanupLeftoverBans() {
-    // queryBanned() returns a paginated slice, so a single pass only clears
-    // the first page. Loop until either the response is empty or we stop
-    // making progress; cap iterations to avoid running forever against a
-    // poisoned app.
-    Set<String> seen = new HashSet<>();
-    for (int round = 0; round < 20; round++) {
+    // The same (userId, shadow, channelCid) triple is only attempted once across
+    // rounds; we keep looping as long as we're still removing something so the
+    // shared CI app eventually drains regardless of how it was poisoned.
+    Set<String> tried = new HashSet<>();
+    for (int round = 0; round < 50; round++) {
       List<Ban> bans;
       try {
         bans = User.queryBanned().request().getBans();
@@ -55,15 +55,59 @@ public class UserTest extends BasicTest {
       for (var ban : bans) {
         if (ban.getUser() == null || ban.getUser().getId() == null) continue;
         String id = ban.getUser().getId();
-        if (!seen.add(id)) continue;
+        boolean shadow = Boolean.TRUE.equals(ban.getShadow());
+        Channel channel = ban.getChannel();
+        String key = id + "|" + shadow + "|" + (channel == null ? "" : channel.getCId());
+        if (!tried.add(key)) continue;
         try {
-          User.unban(id).request();
+          var req = User.unban(id);
+          if (shadow) req.shadow(true);
+          if (channel != null) req.type(channel.getType()).id(channel.getId());
+          req.request();
           unbannedThisRound++;
         } catch (StreamException ignored) {
           // In-use or already-deleted; skip.
         }
       }
       if (unbannedThisRound == 0) return; // No progress; bail.
+    }
+  }
+
+  /**
+   * Look up the current ban for a specific user via {@code query_banned_users} filtered by {@code
+   * user_id}. Returns an empty {@link Optional} when the user has no recorded ban.
+   *
+   * <p>Used by the moderation tests so their assertions do not depend on which slice of the global
+   * ban list happens to come back on the first page of the shared CI app.
+   */
+  private static Optional<Ban> findBanFor(String userId) {
+    try {
+      return User.queryBanned()
+          .filterCondition("user_id", Map.of("$eq", userId))
+          .request()
+          .getBans()
+          .stream()
+          .filter(ban -> ban.getUser() != null && userId.equals(ban.getUser().getId()))
+          .findFirst();
+    } catch (StreamException e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Remove any app-wide ban for {@code userId}, regular or shadow. Errors are swallowed so callers
+   * can use this from a {@code finally} block without masking a real test failure.
+   */
+  private static void bestEffortUnban(String userId) {
+    try {
+      User.unban(userId).request();
+    } catch (StreamException ignored) {
+      // Best-effort cleanup; ignore.
+    }
+    try {
+      User.unban(userId).shadow(true).request();
+    } catch (StreamException ignored) {
+      // Best-effort cleanup; ignore.
     }
   }
 
@@ -225,8 +269,11 @@ public class UserTest extends BasicTest {
     Assertions.assertDoesNotThrow(() -> usersUpsertRequest.request());
     Assertions.assertDoesNotThrow(
         () -> User.ban().userId(testUserRequestObject.getId()).targetUserId(userId).request());
-    List<Ban> bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
-    Assertions.assertTrue(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
+    try {
+      Assertions.assertTrue(findBanFor(userId).isPresent(), "Expected ban for user " + userId);
+    } finally {
+      bestEffortUnban(userId);
+    }
   }
 
   @DisplayName("Can ban user with delete reactions")
@@ -244,8 +291,11 @@ public class UserTest extends BasicTest {
                 .targetUserId(userId)
                 .deleteReactions(true)
                 .request());
-    List<Ban> bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
-    Assertions.assertTrue(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
+    try {
+      Assertions.assertTrue(findBanFor(userId).isPresent(), "Expected ban for user " + userId);
+    } finally {
+      bestEffortUnban(userId);
+    }
   }
 
   @DisplayName("Can shadow ban user")
@@ -259,10 +309,14 @@ public class UserTest extends BasicTest {
     Assertions.assertDoesNotThrow(
         () ->
             User.shadowBan().userId(testUserRequestObject.getId()).targetUserId(userId).request());
-    List<Ban> bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
-    var banned =
-        bans.stream().filter(ban -> ban.getUser().getId().equals(userId)).findFirst().get();
-    Assertions.assertTrue(banned.getShadow());
+    try {
+      var banned =
+          findBanFor(userId)
+              .orElseThrow(() -> new AssertionError("Expected shadow ban for user " + userId));
+      Assertions.assertTrue(banned.getShadow(), "Expected ban to be a shadow ban");
+    } finally {
+      bestEffortUnban(userId);
+    }
   }
 
   @DisplayName("Can list banned user")
@@ -274,8 +328,11 @@ public class UserTest extends BasicTest {
     Assertions.assertDoesNotThrow(() -> usersUpsertRequest.request());
     Assertions.assertDoesNotThrow(
         () -> User.ban().userId(testUserRequestObject.getId()).targetUserId(userId).request());
-    List<Ban> bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
-    Assertions.assertTrue(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
+    try {
+      Assertions.assertTrue(findBanFor(userId).isPresent(), "Expected ban for user " + userId);
+    } finally {
+      bestEffortUnban(userId);
+    }
   }
 
   @DisplayName("Can deactivate user")
@@ -469,11 +526,9 @@ public class UserTest extends BasicTest {
     Assertions.assertDoesNotThrow(() -> usersUpsertRequest.request());
     Assertions.assertDoesNotThrow(
         () -> User.ban().userId(testUserRequestObject.getId()).targetUserId(userId).request());
-    List<Ban> bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
-    Assertions.assertTrue(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
+    Assertions.assertTrue(findBanFor(userId).isPresent(), "Expected ban for user " + userId);
     Assertions.assertDoesNotThrow(() -> User.unban(userId).request());
-    bans = Assertions.assertDoesNotThrow(() -> User.queryBanned().request()).getBans();
-    Assertions.assertFalse(bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId)));
+    Assertions.assertTrue(findBanFor(userId).isEmpty(), "Expected ban to be cleared for " + userId);
   }
 
   @DisplayName("Can remove a shadow ban")


### PR DESCRIPTION
## Summary

- Adds a `findBanFor(userId)` test helper that calls `query_banned_users` with `filter_conditions={"user_id": {"$eq": userId}}`, so the moderation tests stop depending on which slice of the global ban list happens to come back on the first page of the shared CI app.
- Adds a `bestEffortUnban(userId)` helper used from `finally` blocks so each test cleans up after itself (regular + shadow), preventing the shared app from accumulating zombie bans.
- Refactors the five `UserTest` methods that were failing on every recent CI run (including the scheduled jobs on `main`, e.g. [run 26395993503](https://github.com/GetStream/stream-chat-java/actions/runs/26395993503)) to use the helpers: `whenBanUser_thenIsBanned`, `whenBanUserWithDeleteReactions_thenIsBanned`, `whenShadowBanUser_thenIsShadowBanned`, `whenListingBannedUsers_thenContainsBanned`, `whenUnbanUser_thenIsNotBannedAnymore`.
- Tightens the `@BeforeAll cleanupLeftoverBans` sweep so it actually drains shadow and channel-scoped bans. The previous version always called `User.unban(id).request()` with no qualifiers, so any first page dominated by shadow / channel zombies caused it to bail with `unbannedThisRound == 0` and leave the queue stuck.

## Root cause

`User.queryBanned().request()` returns a paginated slice (`limit` defaults to ~50, max 300). The shared test app accumulates zombie bans whenever a prior PR's job dies before its inline teardown fires. Once enough pile up, `bans.stream().anyMatch(ban -> ban.getUser().getId().equals(userId))` fails because the just-banned user is past page 1, and `findFirst().get()` in the shadow-ban test throws `NoSuchElementException`. Filtering `query_banned_users` by `user_id` makes the lookup deterministic regardless of zombie count.

## Test plan

- [x] `./gradlew compileTestJava` (JDK 11 toolchain)
- [x] `./gradlew spotlessCheck`
- [ ] CI `Test & lint` job passes the five previously failing `UserTest` cases
- [ ] Confirm the `cleanupLeftoverBans` sweep keeps draining the CI app over subsequent runs (visible in successive `@BeforeAll` timings / scheduled main runs)

Made with [Cursor](https://cursor.com)