### PR TITLE
test(task-status): bump waitFor budget to 10 minutes

### DIFF
--- a/src/test/java/io/getstream/chat/java/TaskStatusTest.java
+++ b/src/test/java/io/getstream/chat/java/TaskStatusTest.java
@@ -21,8 +21,9 @@ public class TaskStatusTest extends BasicTest {
           var cids = List.of(ch1.getCId(), ch2.getCId());
           var taskId = Channel.deleteMany(cids).request().getTaskId();
           // Shared CI test app: asynq queue can be backed up under load — the
-          // default 5s waitFor is routinely too short. 5 minutes leaves real
-          // headroom without masking a stuck task.
+          // default 5s waitFor is routinely too short, and even the bumped 5
+          // minute budget from #256 was timing out in recent runs. 10 minutes
+          // leaves real headroom without masking a stuck task.
           waitFor(
               () -> {
                 var taskStatusResponse =
@@ -30,7 +31,7 @@ public class TaskStatusTest extends BasicTest {
                 return "completed".equals(taskStatusResponse.getStatus());
               },
               1000L,
-              300000L);
+              600000L);
         });
   }
 }


### PR DESCRIPTION
## Summary

- Doubles the `waitFor` budget in `TaskStatusTest > Can get task status by id` from 5 minutes to 10 minutes.
- The 5-minute budget was set in [#256](https://github.com/GetStream/stream-chat-java/pull/256) because the shared CI app's asynq queue is routinely backed up. That budget is now also timing out — e.g. the latest CI run on PR [#259](https://github.com/GetStream/stream-chat-java/pull/259) ([build 26518080390](https://github.com/GetStream/stream-chat-java/actions/runs/26518080390)) hit the cap while polling `Channel.deleteMany`'s task to completion:

  ```
  TaskStatusTest > Can get task status by id FAILED
      org.opentest4j.AssertionFailedError: Unexpected exception thrown: org.opentest4j.AssertionFailedError
          at io.getstream.chat.java.BasicTest.waitFor(BasicTest.java:160)
      Caused by:
      java.util.concurrent.TimeoutException
  ```

- 10 minutes still surfaces a genuinely stuck queue (waitFor will fail), but gives healthy-but-slow runs enough headroom to actually finish polling.

## Test plan

- [x] `./gradlew compileTestJava` (JDK 11 toolchain)
- [x] `./gradlew spotlessCheck`
- [ ] CI run completes `TaskStatusTest > Can get task status by id` within the new budget

Made with [Cursor](https://cursor.com)